### PR TITLE
Feat: pnpm with cached modules action

### DIFF
--- a/.github/workflows/test-pnpm-with-cached-modules.yaml
+++ b/.github/workflows/test-pnpm-with-cached-modules.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Self pnpm with cached modules should be able to run
+      - name: pnpm with cached modules should be able to run
         uses: ./pnpm-with-cached-modules
         id: pnpm-with-cached-modules
         with:

--- a/.github/workflows/test-pnpm-with-cached-modules.yaml
+++ b/.github/workflows/test-pnpm-with-cached-modules.yaml
@@ -24,4 +24,4 @@ jobs:
         uses: ./pnpm-with-cached-modules
         id: pnpm-with-cached-modules
         with:
-          project_path: ./pnpm-with-cached-modules
+          project_path: ./pnpm-with-cached-modules/test/

--- a/.github/workflows/test-pnpm-with-cached-modules.yaml
+++ b/.github/workflows/test-pnpm-with-cached-modules.yaml
@@ -1,0 +1,27 @@
+name: Test pnpm with cached modules
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**.md"
+  pull_request:
+    paths-ignore:
+      - "**.md"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Self pnpm with cached modules should be able to run
+        uses: ./pnpm-with-cached-modules
+        id: pnpm-with-cached-modules
+        with:
+          project_path: ./pnpm-with-cached-modules

--- a/pnpm-with-cached-modules/action.yml
+++ b/pnpm-with-cached-modules/action.yml
@@ -71,6 +71,6 @@ runs:
       working-directory: ${{ inputs.project_path }}
       # Only prune if we installed all dependencies to prevent pruning something
       # useful that we have to re-download later
-      if: inputs.install_dependencies == 'true' && inputs.skip_postinstall == 'false'
+      if: inputs.install_dependencies == 'true'
       shell: bash
       run: pnpm store prune

--- a/pnpm-with-cached-modules/action.yml
+++ b/pnpm-with-cached-modules/action.yml
@@ -61,12 +61,14 @@ runs:
         key-suffix: ${{ hashFiles('./pnpm-lock.yaml') }}
 
     - name: Install Dependencies
+      working-directory: ${{ inputs.project_path }}
       shell: bash
       run: pnpm install --frozen-lockfile
       if: inputs.install_dependencies == 'true'
 
     # Prevent unused dependencies from being stored in the cache forever
     - name: Prune unused dependencies
+      working-directory: ${{ inputs.project_path }}
       # Only prune if we installed all dependencies to prevent pruning something
       # useful that we have to re-download later
       if: inputs.install_dependencies == 'true' && inputs.skip_postinstall == 'false'

--- a/pnpm-with-cached-modules/action.yml
+++ b/pnpm-with-cached-modules/action.yml
@@ -1,5 +1,5 @@
-name: "Install node, pnpm and packages"
-description: "Install node and pnpm, download and install packages and setup the cache"
+name: "Install node, pnpm and packages using strong caching"
+description: "Install node and pnpm, download and install packages using cached node_modules and pnpm store"
 inputs:
   install_node:
     description: "Whether to skip installation of node"

--- a/pnpm-with-cached-modules/action.yml
+++ b/pnpm-with-cached-modules/action.yml
@@ -1,0 +1,74 @@
+name: "Install node, pnpm and packages"
+description: "Install node and pnpm, download and install packages and setup the cache"
+inputs:
+  install_node:
+    description: "Whether to skip installation of node"
+    required: false
+    default: true
+    type: boolean
+  node_version:
+    description: "The version of node to install"
+    required: false
+    default: 18
+    type: string
+  pnpm_version:
+    description: "The version of pnpm to install"
+    required: false
+    default: 8.14.1
+    type: string
+  install_dependencies:
+    description: "Whether to install dependencies"
+    required: false
+    default: true
+    type: boolean
+  project_path:
+    description: "The path where the package.json and node_modules reside. Expects a path ending in a /"
+    required: false
+    default: "./"
+    type: string
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Node.js
+      uses: actions/setup-node@v4.0.1
+      if: inputs.install_node == 'true'
+      with:
+        node-version: ${{ inputs.node_version }}
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@v2.4.0
+      with:
+        version: ${{ inputs.pnpm_version }}
+        package_json_file: ${{ inputs.project_path }}package.json
+        run_install: false
+
+    - name: Get pnpm store directory
+      id: pnpm-cache
+      shell: bash
+      run: |
+        echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+    - name: Setup pnpm cache
+      uses: aerialops/ci-actions/self-updating-cache@feat/add-self-updating-cache-action
+      # We don't want to cache the result if we're not installing dependencies
+      if: inputs.install_dependencies == 'true'
+      with:
+        path: |
+          ${{ steps.pnpm-cache.outputs.PNPM_STORE_PATH }}
+          ${{ inputs.project_path }}node_modules/
+        key-prefix: pnpm-store-v1
+        key-suffix: ${{ hashFiles('./pnpm-lock.yaml') }}
+
+    - name: Install Dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile
+      if: inputs.install_dependencies == 'true'
+
+    # Prevent unused dependencies from being stored in the cache forever
+    - name: Prune unused dependencies
+      # Only prune if we installed all dependencies to prevent pruning something
+      # useful that we have to re-download later
+      if: inputs.install_dependencies == 'true' && inputs.skip_postinstall == 'false'
+      shell: bash
+      run: pnpm store prune

--- a/pnpm-with-cached-modules/test/README.md
+++ b/pnpm-with-cached-modules/test/README.md
@@ -1,0 +1,2 @@
+Mock project used to test the action.
+Installs `chalk` as a dependency as it's very lightweight.

--- a/pnpm-with-cached-modules/test/package.json
+++ b/pnpm-with-cached-modules/test/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {},
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "chalk": "^5.3.0"
+  }
+}

--- a/pnpm-with-cached-modules/test/pnpm-lock.yaml
+++ b/pnpm-with-cached-modules/test/pnpm-lock.yaml
@@ -1,0 +1,17 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+dependencies:
+  chalk:
+    specifier: ^5.3.0
+    version: 5.3.0
+
+packages:
+
+  /chalk@5.3.0:
+    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: false


### PR DESCRIPTION
Task: https://www.notion.so/Open-Source-pnpm-CI-Actions-63a0f2b09c994a898b877482a246f2d6?pvs=23

Adds the action that installs node, pnpm and modules using the cache, and makes it more versatile as it now allows specifying a project path (which is useful for testing as well) .

Will add READMEs later